### PR TITLE
update deprecated config reference

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -64,7 +64,7 @@
 {{- end }}
 
 <!-- Google Analytics internal template -->
-{{- if .Site.GoogleAnalytics }}
+{{- if .Site.Config.Services.GoogleAnalytics.ID }}
     {{ template "_internal/google_analytics.html" . }}
 {{- end}}
 

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -122,7 +122,7 @@
 
     {{ partial "pagination-single.html" . }}
 
-    {{ if .Site.DisqusShortname }}
+    {{ if .Site.Config.Services.Disqus.Shortname }}
       {{ if not (eq .Params.Comments "false") }}
         <div id="comments">
           {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
resolve deprecation warning:

```log
Start building sites …
hugo v0.129.0-e85be29867d71e09ce48d293ad9d1f715bc09bb9+extended darwin/arm64 BuildDate=2024-07-17T13:29:16Z VendorInfo=gohugoio

WARN  deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.GoogleAnalytics.ID instead.
WARN  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
```